### PR TITLE
Bugfix: Update negation syntax in compute_ground_truth_statistics

### DIFF
--- a/confidenceinterval/delong.py
+++ b/confidenceinterval/delong.py
@@ -190,7 +190,7 @@ def calc_pvalue(aucs, sigma):
 
 def compute_ground_truth_statistics(ground_truth, sample_weight):
     assert np.array_equal(np.unique(ground_truth), [0, 1])
-    order = (-ground_truth).argsort()
+    order = (~ground_truth).argsort()
     label_1_count = int(ground_truth.sum())
     if sample_weight is None:
         ordered_sample_weight = None

--- a/tests/test_delong.py
+++ b/tests/test_delong.py
@@ -1,0 +1,24 @@
+from confidenceinterval.delong import compute_ground_truth_statistics
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    'ground_truth',
+    [
+        (np.array([0,0,1,1,1])), # Values are integers
+        (np.array([False, False, True, True, True])) # values are bools
+        ]
+)
+def test_compute_ground_truth_statistics(ground_truth):
+    sample_weight = np.array([1,1,1,1,1])
+    
+    expected_order = np.array([2,3,4,0,1])
+    expected_label_1_count = 3
+    expected_ordered_sample_weight = np.array([1,1,1,1,1])
+    
+    order, label_1_count, ordered_sample_weight = compute_ground_truth_statistics(ground_truth=ground_truth, sample_weight=sample_weight)
+    
+    assert np.array_equal(expected_order, order)
+    assert expected_label_1_count == label_1_count
+    assert np.array_equal(expected_ordered_sample_weight, ordered_sample_weight)


### PR DESCRIPTION
Hi,

First of all, amazing library - great work! ✨ 

I've spotted a potential bug surrounding negation in `numpy`. The ('-') syntax does not work for reversing a boolean array, which seems to get passed to the `compute_ground_truth_statistics` in certain scenarios (e.g., sometimes, but not always, when asking for the fast delong solver).

I've updated the code to use the tilde sign ('~'). I hope this small change helps as it works for both integer and boolean arrays.

## Error
<img width="1118" alt="image" src="https://github.com/jacobgil/confidenceinterval/assets/148057380/8fa740b2-ec31-4deb-accb-dc3a83c8fc2b">


Minimal reproducible example & test case:


```python
from confidenceinterval.delong import compute_ground_truth_statistics
import numpy as np
import pytest

@pytest.mark.parametrize(
    'ground_truth',
    [
        (np.array([0,0,1,1,1])), # Values are integers
        (np.array([False, False, True, True, True])) # values are bools
        ]
)
def test_compute_ground_truth_statistics_bool(ground_truth):
    
    sample_weight = np.array([1,1,1,1,1])
    
    expected_order = np.array([2,3,4,0,1])
    expected_label_1_count = 3
    expected_ordered_sample_weight = np.array([1,1,1,1,1])
    
    order, label_1_count, ordered_sample_weight = compute_ground_truth_statistics(ground_truth=ground_truth, sample_weight=sample_weight)
    
    assert np.array_equal(expected_order, order)
    assert expected_label_1_count == label_1_count
    assert np.array_equal(expected_ordered_sample_weight, ordered_sample_weight)
``` 

I can add this test to the library if you can let me know where it should go 😄  e.g., a new file called `test_utils.py`, or similar?

Keep up the good work,
Callum